### PR TITLE
Add instructions to README.md to create DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ mkvirtualenv --no-site-packages commcare_sync -p python3.8
 pip install -r requirements.txt
 ```
 
+Create a database:
+
+```bash
+psql -U <dbuser> -h localhost -p 5432
+CREATE DATABASE commcare_sync;
+\q
+./manage.py migrate
+```
+
 ### Running server
 
 ```bash


### PR DESCRIPTION
Fills in a small gap in dev setup instructions.

(I went with instructions for Postgres because that's what's in settings.py.)