### PR TITLE
fixes related to queuing and viewing queues

### DIFF
--- a/apps/exports/admin.py
+++ b/apps/exports/admin.py
@@ -4,17 +4,22 @@ from . import models
 
 
 admin.site.register(models.ExportDatabase)
-admin.site.register(models.MultiProjectExportConfig)
 
 @admin.register(models.ExportConfig)
 class ExportConfigAdmin(admin.ModelAdmin):
-    list_display = ['name', 'project', 'account', 'database', 'created_by', 'is_paused']
-    list_filter = ['project', 'database', 'is_paused']
+    list_display = ['name', 'project', 'account', 'database', 'created_by', 'is_paused', 'created_at', 'updated_at']
+    list_filter = ['project', 'database', 'is_paused', 'created_at', 'updated_at']
 
 @admin.register(models.ExportRun)
 class ExportRunAdmin(admin.ModelAdmin):
     list_display = ['export_config', 'created_at', 'started_at', 'completed_at', 'status']
     list_filter = ['export_config', 'created_at', 'started_at', 'completed_at', 'status']
+
+
+@admin.register(models.MultiProjectExportConfig)
+class MultiProjectExportConfigAdmin(admin.ModelAdmin):
+    list_display = ['name', 'account', 'database', 'created_by', 'is_paused', 'created_at', 'updated_at']
+    list_filter = ['database', 'is_paused', 'created_at', 'updated_at']
 
 
 @admin.register(models.MultiProjectExportRun)

--- a/apps/exports/management/commands/clear_queued_exports.py
+++ b/apps/exports/management/commands/clear_queued_exports.py
@@ -1,0 +1,18 @@
+from itertools import chain
+
+from django.core.management.base import BaseCommand
+
+from apps.exports.models import ExportRun, MultiProjectExportRun
+
+
+class Command(BaseCommand):
+    help = 'Clears all exports with status "queued".'
+
+    def handle(self, **options):
+        queued_runs = chain(
+            ExportRun.objects.filter(status=ExportRun.QUEUED),
+            MultiProjectExportRun.objects.filter(status=ExportRun.QUEUED)
+        )
+        for export_run in queued_runs:
+
+            export_run.mark_skipped()

--- a/apps/exports/models.py
+++ b/apps/exports/models.py
@@ -45,6 +45,11 @@ class ExportConfigBase(BaseModel):
     def is_scheduled_to_run(self):
         return export_is_scheduled_to_run(self, self.last_run)
 
+    def has_queued_runs(self):
+        if self.runs.exists():
+            # queued runs that aren't the latest should be ignored so just check the latest one
+            return self.runs.order_by('-created_at')[0].status == ExportRun.QUEUED
+        return False
 
 class ExportConfig(ExportConfigBase):
     project = models.ForeignKey('commcare.CommCareProject', on_delete=models.CASCADE)

--- a/apps/exports/models.py
+++ b/apps/exports/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from apps.commcare.models import BaseModel
 from apps.exports.scheduling import export_is_scheduled_to_run
@@ -123,6 +124,12 @@ class ExportRunBase(BaseModel):
         formatted_log = str(self.log).replace('\n', '<br>') if self.log else ''
         return mark_safe(formatted_log)
 
+    def mark_skipped(self):
+        if not self.status == ExportRun.QUEUED:
+            raise Exception("Can't mark a run that has been started skipped!")
+        self.status = ExportRun.SKIPPED
+        self.completed_at = timezone.now()
+        self.save()
 
 class ExportRun(ExportRunBase):
     export_config = models.ForeignKey(ExportConfig, on_delete=models.CASCADE, related_name='runs')

--- a/apps/exports/models.py
+++ b/apps/exports/models.py
@@ -112,8 +112,8 @@ class ExportRunBase(BaseModel):
 
     @property
     def duration(self):
-        if self.completed_at:
-            return self.completed_at - self.created_at
+        if self.completed_at and self.started_at:
+            return self.completed_at - self.started_at
         else:
             return None
 

--- a/apps/exports/tasks.py
+++ b/apps/exports/tasks.py
@@ -34,9 +34,7 @@ def run_export_task(self, export_run_id, force_sync_all_data, ignore_schedule_ch
             'log': export_run.log,
         }
     else:
-        export_run.status = ExportRun.SKIPPED
-        export_run.completed_at = timezone.now()
-        export_run.save()
+        export_run.mark_skipped()
 
 
 @shared_task(bind=True)

--- a/apps/exports/tasks.py
+++ b/apps/exports/tasks.py
@@ -10,11 +10,11 @@ from .runner import run_export, run_multi_project_export
 @shared_task(bind=True)
 def run_all_exports_task(self):
     for export in ExportConfig.objects.filter(is_paused=False):
-        if export.is_scheduled_to_run():
+        if export.is_scheduled_to_run() and not export.has_queued_runs():
             export_record = ExportRun.objects.create(export_config=export, triggered_from_ui=False)
             run_export_task.delay(export_record.id, force_sync_all_data=False)
     for multi_export in MultiProjectExportConfig.objects.filter(is_paused=False):
-        if multi_export.is_scheduled_to_run():
+        if multi_export.is_scheduled_to_run() and not multi_export.has_queued_runs():
             multi_export_record = MultiProjectExportRun.objects.create(export_config=multi_export, triggered_from_ui=False)
             run_multi_project_export_task.delay(multi_export_record.id, force_sync_all_data=False)
 

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -120,13 +120,15 @@ def delete_export_config(request, export_id):
 def export_details(request, export_id):
     export = get_object_or_404(ExportConfig, id=export_id)
     runs = export.runs
-    if _get_hide_skipped_from_request(request):
+    hide_skipped = _get_hide_skipped_from_request(request)
+    if hide_skipped:
         runs = runs.exclude(status__in=[ExportRun.SKIPPED, ExportRun.QUEUED])
 
     return render(request, 'exports/export_details.html', {
         'active_tab': 'exports',
         'export': export,
         'runs': runs.order_by('-created_at')[:_get_ui_page_size(request)],
+        'hide_skipped': hide_skipped,
     })
 
 
@@ -134,13 +136,15 @@ def export_details(request, export_id):
 def multi_export_details(request, export_id):
     export = get_object_or_404(MultiProjectExportConfig, id=export_id)
     runs = export.runs
-    if _get_hide_skipped_from_request(request):
+    hide_skipped = _get_hide_skipped_from_request(request)
+    if hide_skipped:
         runs = runs.exclude(status__in=[ExportRun.SKIPPED, ExportRun.QUEUED])
 
     return render(request, 'exports/multi_project_export_details.html', {
         'active_tab': 'exports',
         'export': export,
         'runs': runs.order_by('-created_at')[:_get_ui_page_size(request)],
+        'hide_skipped': hide_skipped,
     })
 
 @login_required

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -121,7 +121,7 @@ def export_details(request, export_id):
     return render(request, 'exports/export_details.html', {
         'active_tab': 'exports',
         'export': export,
-        'runs': export.runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
+        'runs': export.runs.order_by('-created_at')[:_get_ui_page_size(request)],
     })
 
 
@@ -131,7 +131,7 @@ def multi_export_details(request, export_id):
     return render(request, 'exports/multi_project_export_details.html', {
         'active_tab': 'exports',
         'export': export,
-        'runs': export.runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
+        'runs': export.runs.order_by('-created_at')[:_get_ui_page_size(request)],
     })
 
 @login_required
@@ -143,7 +143,7 @@ def multi_export_run_details(request, export_id, run_id):
         'active_tab': 'exports',
         'export_run': export_run,
         'export': export_run.export_config,
-        'runs': export_run.partial_runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
+        'runs': export_run.partial_runs.order_by('-created_at')[:_get_ui_page_size(request)],
     })
 
 @login_required
@@ -214,3 +214,13 @@ def edit_database(request, database_id):
         'active_tab': 'create_export',
         'form': form,
     })
+
+
+def _get_ui_page_size(request):
+    limit = settings.COMMCARE_SYNC_UI_PAGE_SIZE
+    if 'limit' in request.GET:
+        try:
+            limit = int(request.GET['limit'])
+        except ValueError:
+            pass
+    return limit

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect, Http404
@@ -120,7 +121,7 @@ def export_details(request, export_id):
     return render(request, 'exports/export_details.html', {
         'active_tab': 'exports',
         'export': export,
-        'runs': export.runs.order_by('-created_at')[:25],
+        'runs': export.runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
     })
 
 
@@ -130,7 +131,7 @@ def multi_export_details(request, export_id):
     return render(request, 'exports/multi_project_export_details.html', {
         'active_tab': 'exports',
         'export': export,
-        'runs': export.runs.order_by('-created_at')[:25],
+        'runs': export.runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
     })
 
 @login_required
@@ -142,7 +143,7 @@ def multi_export_run_details(request, export_id, run_id):
         'active_tab': 'exports',
         'export_run': export_run,
         'export': export_run.export_config,
-        'runs': export_run.partial_runs.order_by('-created_at')[:25],
+        'runs': export_run.partial_runs.order_by('-created_at')[:settings.COMMCARE_SYNC_UI_PAGE_SIZE],
     })
 
 @login_required

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -1,4 +1,3 @@
-import distutils
 import json
 
 from django.conf import settings
@@ -145,6 +144,7 @@ def multi_export_details(request, export_id):
         'export': export,
         'runs': runs.order_by('-created_at')[:_get_ui_page_size(request)],
         'hide_skipped': hide_skipped,
+
     })
 
 @login_required
@@ -241,5 +241,5 @@ def _get_ui_page_size(request):
 
 def _get_hide_skipped_from_request(request):
     if 'hide_skipped' in request.GET:
-        return bool(distutils.util.strtobool(request.GET['hide_skipped']))
+        return request.GET['hide_skipped'] == 'y'
     return False

--- a/commcare_sync/settings.py
+++ b/commcare_sync/settings.py
@@ -234,6 +234,7 @@ COMMCARE_DEFAULT_SERVER = 'https://www.commcarehq.org/'
 COMMCARE_EXPORT = 'commcare-export'  # replace with absolute path if you need
 
 COMMCARE_SYNC_EXPORT_PERIODICITY = 60 * 60 * 12  # run everything every 12 hours by default
+COMMCARE_SYNC_UI_PAGE_SIZE = 25
 
 # Project config
 

--- a/templates/exports/export_details.html
+++ b/templates/exports/export_details.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 {% extends "web/app/app_base.html" %}
 {% load static %}
 {% load dateformat_tags %}
@@ -44,6 +45,12 @@
       <span class="heading">Created By</span>
       <h2>
         {% if request.user == export.created_by %}You{% else %}{{ export.created_by.username}}{% endif %}
+      </h2>
+    </div>
+    <div class="column">
+      <span class="heading">Last Modified</span>
+      <h2>
+        {{ export.updated_at|naturaltime }}
       </h2>
     </div>
   </div>

--- a/templates/exports/export_details.html
+++ b/templates/exports/export_details.html
@@ -1,5 +1,5 @@
-{% load humanize %}
 {% extends "web/app/app_base.html" %}
+{% load humanize %}
 {% load static %}
 {% load dateformat_tags %}
 {% block app %}

--- a/templates/exports/partials/multi_export_details.html
+++ b/templates/exports/partials/multi_export_details.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 <section class="section app-card">
   <div class="level">
     <!-- Left side -->
@@ -41,6 +42,12 @@
       <span class="heading">Created By</span>
       <h2>
         {% if request.user == export.created_by %}You{% else %}{{ export.created_by.username}}{% endif %}
+      </h2>
+    </div>
+    <div class="column">
+      <span class="heading">Last Modified</span>
+      <h2>
+        {{ export.updated_at|naturaltime }}
       </h2>
     </div>
   </div>

--- a/templates/exports/partials/run_history.html
+++ b/templates/exports/partials/run_history.html
@@ -15,9 +15,15 @@
     </div>
     <div class="level-right">
       <label>Filter</label>
-      <a class="button is-primary is-outlined is-small mx-2" href="?hide_skipped=y">
+      {% if hide_skipped %}
+        <a class="button is-primary is-rounded is-outlined is-small mx-2" href="?hide_skipped=n">
+          <span>Show Queued and Skipped Items</span>
+        </a>
+      {% else %}
+      <a class="button is-primary is-rounded is-outlined is-small mx-2" href="?hide_skipped=y">
         <span>Hide Queued and Skipped Items</span>
       </a>
+      {% endif %}
     </div>
   </div>
   <div id="export-status-progress" class="progress-bar-demo my-2" style="display: none;">

--- a/templates/exports/partials/run_history.html
+++ b/templates/exports/partials/run_history.html
@@ -1,15 +1,25 @@
 <section class="section app-card">
   <h1 class="title">Run History</h1>
-  <button class="button is-primary is-rounded is-small" id="run-export-button">
-    <span class="icon">
-      <i class="fa fa-play"></i>
-    </span>
-    <span>Run Now</span>
-  </button>
-  <label class="checkbox mx-2 my-1">
-    <input type="checkbox" id="force-sync-checkbox">
-    Force sync of all data
-  </label>
+  <div class="level">
+    <div class="level-left">
+      <button class="button is-primary is-rounded is-small" id="run-export-button">
+        <span class="icon">
+          <i class="fa fa-play"></i>
+        </span>
+        <span>Run Now</span>
+      </button>
+      <label class="checkbox mx-2 my-1">
+        <input type="checkbox" id="force-sync-checkbox">
+        Force sync of all data
+      </label>
+    </div>
+    <div class="level-right">
+      <label>Filter</label>
+      <a class="button is-primary is-outlined is-small mx-2" href="?hide_skipped=y">
+        <span>Hide Queued and Skipped Items</span>
+      </a>
+    </div>
+  </div>
   <div id="export-status-progress" class="progress-bar-demo my-2" style="display: none;">
     <div class='progress-wrapper'>
       <progress id="progress-bar" class="progress is-small is-primary" max="100"></progress>


### PR DESCRIPTION
Work done in relation to https://dimagi-dev.atlassian.net/browse/SAAS-11532

Recommend reviewing by commit. The most important piece is fixing the logic to not create/queue export runs if there are already pending runs for that export (https://github.com/dimagi/commcare-sync/commit/91adcd7d70ffa7fc6bb1d1f8fe4801f21550f06d)

This also:
- adds the ability to increase the page size of runs in the UI, either by a url param or a settings variable (useful for seeing how much is there)
- adds a button to show/hide skipped and pending runs from the UI (useful for ignoring all the ones that haven't done anything)
- adds a management command to mark all queued exports as "skipped"
- fixes some of the running logic, in case tasks are called more than once, to prevent multiple runs of the same thing
- fixes the "duration" display when a run is skipped

I've already deployed these changes to the USH environment (and run `clear_queued_exports`) so that mike can play with them

![image](https://user-images.githubusercontent.com/66555/99375497-7a95a900-28cc-11eb-90b1-0c1bc6161437.png)
