### PR TITLE
use identicons instead of default profile picture

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -23,11 +23,10 @@ class CustomUser(AbstractUser):
 
     @property
     def avatar_url(self):
-        default_avatar_image = 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/User_font_awesome.svg/512px-User_font_awesome.svg.png'  # noqa
         if self.avatar:
             return self.avatar.url
         else:
-            return 'https://www.gravatar.com/avatar/{}?s=128&d={}'.format(self.gravatar_id, default_avatar_image)
+            return 'https://www.gravatar.com/avatar/{}?s=128&d=identicon'.format(self.gravatar_id)
 
     @property
     def gravatar_id(self):


### PR DESCRIPTION
This changes the default user avatar to be automatically generated by gravtar. They look like this and are unique per user.

![image](https://user-images.githubusercontent.com/66555/104585477-bcdd2b80-566c-11eb-8551-f29029e264a7.png)

PR-ing into the travis branch to avoid conflicts.