### PR TITLE
Fix default server configuration

### DIFF
--- a/apps/commcare/migrations/0001_initial.py
+++ b/apps/commcare/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(default='CommCare HQ', max_length=100)),
-                ('url', models.CharField(default='https://www.commcarehq.org/', max_length=100)),
+                ('url', models.CharField(default='https://www.commcarehq.org', max_length=100)),
             ],
             options={
                 'abstract': False,

--- a/apps/commcare/migrations/0003_auto_20200513_0905.py
+++ b/apps/commcare/migrations/0003_auto_20200513_0905.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='commcareserver',
             name='url',
-            field=models.CharField(default='https://www.commcarehq.org/', max_length=100, unique=True),
+            field=models.CharField(default='https://www.commcarehq.org', max_length=100, unique=True),
         ),
     ]

--- a/apps/exports/runner.py
+++ b/apps/exports/runner.py
@@ -78,7 +78,7 @@ def _compile_export_command(export_config, project, force):
         '--batch-size', str(export_config.batch_size),
         '--verbose',
         '--query', export_config.config_file.path,
-        '--commcare-hq', project.server.url,
+        '--commcare-hq', project.server.url.rstrip('/'),
     ]
     if force:
         command.append('--start-over')

--- a/apps/exports/tests/test_runner.py
+++ b/apps/exports/tests/test_runner.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from apps.commcare.models import CommCareServer, CommCareProject, CommCareAccount
@@ -9,6 +9,7 @@ from apps.exports.runner import _compile_export_command
 
 
 class TestRunnerArguments(SimpleTestCase):
+
     def test_custom_server_url(self):
         server = CommCareServer(name="Test Server", url="https://www.example.com")
         project = CommCareProject(server=server, domain="foo")
@@ -31,3 +32,29 @@ class TestRunnerArguments(SimpleTestCase):
         command = _compile_export_command(export_config, project, force=False)
 
         self.assertIn(server.url, command)
+
+
+class RunnerArgumentsDbTest(TestCase):
+
+    def test_default_server_url(self):
+        server = CommCareServer.objects.get()
+        project = CommCareProject(server=server, domain="foo")
+        account = CommCareAccount(server=server, username="foo", api_key="P@ssWord")
+        database = ExportDatabase(
+            name="Test DB", connection_string="postgresql://foo:bar@123.4.0.0/test"
+        )
+        config_file = TemporaryUploadedFile(
+            name="config_file", content_type="application/xml", size=100, charset="utf-8"
+        )
+        export_config = ExportConfig(
+            name="Test Config",
+            project=project,
+            account=account,
+            database=database,
+            config_file=config_file,
+            extra_args="",
+        )
+
+        command = _compile_export_command(export_config, project, force=False)
+
+        self.assertIn('https://www.commcarehq.org', command)

--- a/commcare_sync/settings.py
+++ b/commcare_sync/settings.py
@@ -227,7 +227,7 @@ CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
 # CommCare Config
 
-COMMCARE_DEFAULT_SERVER = 'https://www.commcarehq.org/'
+COMMCARE_DEFAULT_SERVER = 'https://www.commcarehq.org'
 COMMCARE_EXPORT = 'commcare-export'  # replace with absolute path if you need
 
 COMMCARE_SYNC_EXPORT_PERIODICITY = 60 * 60 * 12  # run everything every 12 hours by default


### PR DESCRIPTION
Accidentally introduced in #27 because of https://github.com/dimagi/commcare-export/issues/172

Also will fix the root problem on new installs but won't bother migrating existing servers.