### PR TITLE
better error message when trying to access db config as a non-superuser

### DIFF
--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -247,7 +247,7 @@ def databases(request):
     })
 
 
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.is_superuser, login_url='/admin-required')
 def create_database(request):
     if request.method == 'POST':
         form = CreateExportDatabaseForm(request.POST, request.FILES)

--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -5,7 +5,6 @@ from . import views
 
 app_name = 'web'
 urlpatterns = [
-    path(r'', views.home, name='home'),
-
-    path(r'terms', TemplateView.as_view(template_name="web/terms.html"), name='terms'),
+    path('', views.home, name='home'),
+    path('terms', TemplateView.as_view(template_name="web/terms.html"), name='terms'),
 ]

--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -6,5 +6,6 @@ from . import views
 app_name = 'web'
 urlpatterns = [
     path('', views.home, name='home'),
+    path('admin-required', views.admin_required, name='admin_required'),
     path('terms', TemplateView.as_view(template_name="web/terms.html"), name='terms'),
 ]

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -8,3 +10,11 @@ def home(request):
         return HttpResponseRedirect(reverse('exports:home'))
     else:
         return render(request, 'web/landing_page.html')
+
+
+@login_required
+def admin_required(request):
+    if request.user.is_superuser:
+        return HttpResponseRedirect(request.GET.get('next', reverse('web:home')))
+    else:
+        return render(request, 'web/admin_required.html', {'dev_mode': settings.DEBUG})

--- a/templates/web/admin_required.html
+++ b/templates/web/admin_required.html
@@ -1,0 +1,23 @@
+{% extends "web/base.html" %}
+{% load static %}
+{% block body %}
+<section class="section container">
+    <div class="columns columns-reversed">
+        <div class="column">
+            <img src="{% static 'images/undraw/undraw_alert.svg' %}" alt="Uh-Oh">
+        </div>
+        <div id="tagline" class="column">
+            <h1 class="title is-size-3">You have to be an administrator to do that.</h1>
+            <h2 class="subtitle is-size-5">
+                If you think you should have access to this page, contact someone on your support team.
+            </h2>
+          {% if dev_mode %}
+          <p>
+            In development you can fix this problem by running the command below and refreshing the page:
+            <pre>./manage.py promote_user_to_superuser {{ user.username }}</pre>.
+          </p>
+          {% endif %}
+        </div>
+    </div>
+</section>
+{% endblock%}


### PR DESCRIPTION
currently this redirects to the login page, which then redirects to the db page and causes an infinite redirection loop.

this replaces it with a clearer error, and instructions for fixing if `DEBUG` is enabled.