### PR TITLE
Adds `is_in_use()` method

### DIFF
--- a/apps/commcare/models.py
+++ b/apps/commcare/models.py
@@ -108,6 +108,12 @@ class CommCareProject(BaseModel):
     def url(self):
         return f'{self.server.get_url_base()}/a/{self.domain}/'
 
+    def is_in_use(self):
+        return (
+            self.exportconfig_set.exists()
+            or self.multiprojectexportconfig_set.exists()
+        )
+
 
 class CommCareAccount(BaseModel):
     server = models.ForeignKey(CommCareServer, on_delete=models.CASCADE)
@@ -152,3 +158,9 @@ class CommCareAccount(BaseModel):
         fernet = Fernet(key.encode() if isinstance(key, str) else key)
         encrypted = fernet.encrypt(value.encode())
         self.api_key_encrypted = encrypted.decode()
+
+    def is_in_use(self):
+        return (
+            self.exportconfig_set.exists()
+            or self.multiprojectexportconfig_set.exists()
+        )

--- a/apps/commcare/tests/test_models.py
+++ b/apps/commcare/tests/test_models.py
@@ -1,18 +1,25 @@
 from cryptography.fernet import Fernet
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.test import override_settings
+from unmagic import fixture, use
 
-from apps.commcare.models import CommCareAccount, CommCareServer
+from apps.commcare.models import (
+    CommCareAccount,
+    CommCareServer,
+)
+from apps.db.models import Database
+from apps.exports.models import ExportConfig
+from tests.fixtures import commcare_project, commcare_server, user
 
 
 class TestCommCareAccountAPIKey:
-
     def setup_method(self):
         User = get_user_model()
         user = User(
             username='testuser',
             email='test@example.com',
-            password='testpass123',
+            password='testpass',
         )
         server = CommCareServer(
             name='Test Server',
@@ -70,3 +77,87 @@ class TestCommCareAccountAPIKey:
         fernet = Fernet(current_key)
         decrypted_bytes = fernet.decrypt(encrypted_bytes)
         assert decrypted_bytes.decode() == test_api_key
+
+
+@fixture
+def account():
+    """CommCareAccount with FERNET_KEYS set for api_key encryption."""
+    with override_settings(FERNET_KEYS=[Fernet.generate_key()]):
+        a = CommCareAccount(
+            server=commcare_server(),
+            username='test@example.com',
+            owner=user(),
+        )
+        a.api_key = 'dummy-key'
+        a.save()
+    yield a
+
+
+@use('db')
+class TestCommCareProjectIsInUse:
+    @use(commcare_project)
+    def test_not_in_use_when_no_configs(self):
+        assert commcare_project().is_in_use() is False
+
+    @use(commcare_project, account)
+    def test_in_use_when_exportconfig_exists(self):
+        project = commcare_project()
+        with override_settings(FERNET_KEYS=[Fernet.generate_key()]):
+            db_obj = Database(name='Test DB')
+            db_obj.connection_string = 'postgresql://localhost/testdb'
+            db_obj.save()
+
+        config = ExportConfig(
+            name='Test Export',
+            account=account(),
+            database=db_obj,
+            project=project,
+        )
+        config.config_file.save('test.xlsx', ContentFile(b''), save=False)
+        config.save()
+        assert project.is_in_use() is True
+
+    @use(commcare_project, account)
+    def test_not_in_use_after_config_deleted(self):
+        project = commcare_project()
+        with override_settings(FERNET_KEYS=[Fernet.generate_key()]):
+            db_obj = Database(name='Test DB 2')
+            db_obj.connection_string = 'postgresql://localhost/testdb2'
+            db_obj.save()
+
+        config = ExportConfig(
+            name='Test Export 2',
+            account=account(),
+            database=db_obj,
+            project=project,
+        )
+        config.config_file.save('test2.xlsx', ContentFile(b''), save=False)
+        config.save()
+        config.delete()
+        assert project.is_in_use() is False
+
+
+@use('db')
+class TestCommCareAccountIsInUse:
+    @use(account)
+    def test_not_in_use_when_no_configs(self):
+        assert account().is_in_use() is False
+
+    @use(commcare_project, account)
+    def test_in_use_when_exportconfig_exists(self):
+        project = commcare_project()
+        acct = account()
+        with override_settings(FERNET_KEYS=[Fernet.generate_key()]):
+            db_obj = Database(name='Test DB')
+            db_obj.connection_string = 'postgresql://localhost/testdb'
+            db_obj.save()
+
+        config = ExportConfig(
+            name='Test Export',
+            account=acct,
+            database=db_obj,
+            project=project,
+        )
+        config.config_file.save('test.xlsx', ContentFile(b''), save=False)
+        config.save()
+        assert acct.is_in_use() is True

--- a/apps/db/models.py
+++ b/apps/db/models.py
@@ -54,3 +54,11 @@ class Database(BaseModel):
         """
         scheme = urlsplit(self.connection_string).scheme
         return scheme.split('+')[0] if '+' in scheme else scheme
+
+    def is_in_use(self):
+        return (
+            self.exportconfig_set.exists()
+            or self.multiprojectexportconfig_set.exists()
+            or self.forwardingconfig_set.exists()
+            or self.refreshconfig_set.exists()
+        )

--- a/apps/db/tests/test_models.py
+++ b/apps/db/tests/test_models.py
@@ -1,9 +1,13 @@
 import doctest
 
 from cryptography.fernet import Fernet
+from django.contrib.auth import get_user_model
 from django.test import override_settings
+from unmagic import fixture, use
 
 from apps.db.models import Database
+
+User = get_user_model()
 
 
 class TestDatabaseConnectionString:
@@ -66,3 +70,59 @@ def test_doctests():
 
     results = doctest.testmod(module)
     assert results.failed == 0
+
+
+@fixture
+@use('db')
+def database_for_is_in_use():
+    """A persisted Database for is_in_use tests (avoids hitting FERNET_KEYS)."""
+    db_obj = Database(name='Test DB IsInUse')
+    db_obj.connection_string = 'postgresql://localhost/testdb'
+    db_obj.save()
+    yield db_obj
+
+
+@use('db')
+class TestDatabaseIsInUse:
+    @use(database_for_is_in_use)
+    def test_not_in_use_when_no_configs(self):
+        assert database_for_is_in_use().is_in_use() is False
+
+    @use(database_for_is_in_use)
+    def test_is_in_use_when_export_config_exists(self):
+        from django.core.files.base import ContentFile
+
+        from apps.commcare.models import (
+            CommCareAccount,
+            CommCareProject,
+            CommCareServer,
+        )
+        from apps.exports.models import ExportConfig
+
+        db_obj = database_for_is_in_use()
+        server = CommCareServer.objects.create(
+            name='Test Server', url='https://test.commcarehq.org'
+        )
+        project = CommCareProject.objects.create(
+            server=server, domain='test-domain'
+        )
+        owner = User.objects.create_user(
+            username='db_is_in_use_owner',
+            email='dbisinuse@example.com',
+            password='testpass',
+        )
+        account = CommCareAccount(
+            server=server, username='test@example.com', owner=owner
+        )
+        account.api_key = 'dummy-key'
+        account.save()
+
+        config = ExportConfig(
+            name='Test Export',
+            account=account,
+            database=db_obj,
+            project=project,
+        )
+        config.config_file.save('test.xlsx', ContentFile(b''), save=False)
+        config.save()
+        assert db_obj.is_in_use() is True

--- a/apps/db/tests/test_views.py
+++ b/apps/db/tests/test_views.py
@@ -1,9 +1,18 @@
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.test import Client
 from django.urls import reverse
 from unmagic import fixture, use
 
+from apps.commcare.models import (
+    CommCareAccount,
+    CommCareProject,
+    CommCareServer,
+)
+from apps.exports.models import ExportConfig
 from tests.fixtures import database
+
+from ..models import Database
 
 User = get_user_model()
 
@@ -134,3 +143,53 @@ class TestDeleteDatabaseView:
         response = admin_client().post(url)
         assert response.status_code == 302
         assert reverse('db:databases') in response.url
+
+
+@fixture
+@use('db')
+def database_in_use():
+    server = CommCareServer.objects.create(
+        name='Test', url='https://test.commcarehq.org'
+    )
+    project = CommCareProject.objects.create(server=server, domain='test')
+    account = CommCareAccount(
+        server=server, username='test@example.com', owner=admin_user()
+    )
+    account.api_key = 'dummy'
+    account.save()
+
+    db_obj = Database(name='In Use DB')
+    db_obj.connection_string = 'postgresql://localhost/testdb'
+    db_obj.save()
+
+    config = ExportConfig(
+        name='Test Export',
+        account=account,
+        database=db_obj,
+        project=project,
+    )
+    config.config_file.save('test.xlsx', ContentFile(b''), save=False)
+    config.save()
+
+    yield db_obj
+
+
+class TestDeleteDatabaseViewInUseGuard:
+    @use(admin_client, database_in_use)
+    def test_post_on_in_use_database_redirects_with_error(self):
+        db_obj = database_in_use()
+        url = reverse('db:delete_database', args=[db_obj.id])
+        response = admin_client().post(url)
+        assert response.status_code == 302
+        assert reverse('db:databases') in response.url
+        # Database must still exist
+        assert Database.objects.filter(id=db_obj.id).exists()
+
+    @use(admin_client, database_in_use)
+    def test_get_on_in_use_database_redirects_with_error(self):
+        db_obj = database_in_use()
+        url = reverse('db:delete_database', args=[db_obj.id])
+        response = admin_client().get(url)
+        assert response.status_code == 302
+        assert reverse('db:databases') in response.url
+        assert Database.objects.filter(id=db_obj.id).exists()

--- a/apps/db/views.py
+++ b/apps/db/views.py
@@ -75,6 +75,9 @@ def edit_database(request, database_id):
 @admin_required
 def delete_database(request, database_id):
     db = get_object_or_404(Database, id=database_id)
+    if db.is_in_use():
+        messages.error(request, f'Cannot delete "{db.name}": It is currently in use.')
+        return HttpResponseRedirect(reverse('db:databases'))
     if request.method == 'POST':
         db.delete()
         messages.success(

--- a/apps/forwarding/models.py
+++ b/apps/forwarding/models.py
@@ -30,6 +30,9 @@ class ForwardingDestination(BaseModel):
     def __str__(self):
         return self.name
 
+    def is_in_use(self):
+        return self.forwardingconfig_set.exists()
+
 
 @reversion.register()
 class ForwardingConfig(ScheduleMixin, BaseModel):

--- a/apps/forwarding/tests/test_models.py
+++ b/apps/forwarding/tests/test_models.py
@@ -502,3 +502,29 @@ class TestForwardingScheduling:
 
         assert cfg.is_paused is True
 
+
+@use('db')
+class TestForwardingDestinationIsInUse:
+    def test_not_in_use_when_no_configs(self):
+        dest = ForwardingDestination.objects.create(
+            name='IsInUse Destination',
+            api_url='https://example.com/api/',
+        )
+        assert dest.is_in_use() is False
+
+    def test_is_in_use_when_forwarding_config_exists(self):
+        dest = ForwardingDestination.objects.create(
+            name='IsInUse Destination',
+            api_url='https://example.com/api/',
+        )
+        db = Database.objects.create(
+            name='IsInUse DB',
+            connection_string='postgresql://localhost/testdb',
+        )
+        ForwardingConfig.objects.create(
+            name='IsInUse Config',
+            database=db,
+            destination=dest,
+            query='SELECT 1',
+        )
+        assert dest.is_in_use() is True


### PR DESCRIPTION
This branch adds an `is_in_use()` method to `CommCareAccount`, `CommCareProject`, `Database`, and `ForwardingDestination` to guard against deletion while an instance is still being used by a related model.

It also adds a check to the `delete_database` view. Similar views will be added for the other models in the next branch.