### PR TITLE
Switch to hamburger menu

### DIFF
--- a/templates/web/components/app_nav.html
+++ b/templates/web/components/app_nav.html
@@ -121,39 +121,4 @@
       </a>
     </li>
   </ul>
-  <hr />
-  <h6 class="text-muted text-uppercase small fw-bold mt-3 d-md-none d-lg-block">
-    {% trans "My Account" %}
-  </h6>
-  <ul class="nav flex-column">
-    <li class="nav-item">
-      <a
-        class="nav-link icon-link {% if active_tab == 'profile' %}active{% endif %}"
-        href="{% url 'users:user_profile' %}"
-      >
-        <i class="fa-solid fa-user"></i
-        ><span class="d-md-none d-lg-inline">{% trans "Profile" %}</span>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a
-        class="nav-link icon-link {% if 'accounts/password/change' in request.path %}active{% endif %}"
-        href="{% url 'account_change_password' %}"
-      >
-        <i class="fa-solid fa-unlock-keyhole"></i
-        ><span class="d-md-none d-lg-inline"
-          >{% trans "Change Password" %}</span
-        >
-      </a>
-    </li>
-    <li class="nav-item">
-      <a
-        class="nav-link icon-link {% if 'accounts/logout' in request.path %}active{% endif %}"
-        href="{% url 'account_logout' %}"
-      >
-        <i class="fa-solid fa-right-from-bracket"></i
-        ><span class="d-md-none d-lg-inline">{% trans "Sign out" %}</span>
-      </a>
-    </li>
-  </ul>
 </aside>

--- a/templates/web/components/top_nav.html
+++ b/templates/web/components/top_nav.html
@@ -31,13 +31,6 @@
     <div class="collapse navbar-collapse" id="nav-menu">
       <ul class="navbar-nav ms-auto">
         {% if user.is_authenticated %}
-          {% if user.is_admin %}
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'admin:index' %}">
-                {% trans "Admin Site" %}
-              </a>
-            </li>
-          {% endif %}
           <li class="nav-item dropdown">
             <a
               class="nav-link dropdown-toggle"
@@ -47,16 +40,31 @@
               data-bs-toggle="dropdown"
               aria-expanded="false"
             >
-              <img
-                class="avatar d-none d-lg-inline-block"
-                src="{{ user.avatar_url }}"
-              />
-              <span class="d-lg-none">{% trans "My Account" %}</span>
+              <i class="fa-solid fa-bars"></i>
+              <span class="visually-hidden">{% trans "Menu" %}</span>
             </a>
             <ul
               class="dropdown-menu dropdown-menu-end"
               aria-labelledby="navbarDropdown"
             >
+              {% if user.is_admin %}
+                <li>
+                  <a class="dropdown-item" href="{% url 'admin:index' %}">
+                    <i class="fa-solid fa-screwdriver-wrench"></i>
+                    {% trans "Admin Site" %}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    class="dropdown-item"
+                    href="{% url 'exports:download_commcare_export_log' %}"
+                  >
+                    <i class="fa-solid fa-download"></i>
+                    {% trans "Download Logs" %}
+                  </a>
+                </li>
+                <li><hr class="dropdown-divider" /></li>
+              {% endif %}
               <li>
                 <a class="dropdown-item" href="{% url 'users:user_profile' %}">
                   <i class="fa-solid fa-user"></i> {% trans "Profile" %}
@@ -67,12 +75,14 @@
                   class="dropdown-item"
                   href="{% url 'account_change_password' %}"
                 >
-                  <i class="fa-solid fa-unlock-keyhole"></i> {% trans "Change Password" %}
+                  <i class="fa-solid fa-unlock-keyhole"></i>
+                  {% trans "Change Password" %}
                 </a>
               </li>
               <li>
                 <a class="dropdown-item" href="{% url 'account_logout' %}">
-                  <i class="fa-solid fa-right-from-bracket"></i> {% trans "Sign out" %}
+                  <i class="fa-solid fa-right-from-bracket"></i>
+                  {% trans "Sign out" %}
                 </a>
               </li>
             </ul>

--- a/templates/web/components/top_nav.html
+++ b/templates/web/components/top_nav.html
@@ -82,7 +82,7 @@
               <li>
                 <a class="dropdown-item" href="{% url 'account_logout' %}">
                   <i class="fa-solid fa-right-from-bracket"></i>
-                  {% trans "Sign out" %}
+                  {% trans "Sign Out" %}
                 </a>
               </li>
             </ul>

--- a/templates/web/components/top_nav.html
+++ b/templates/web/components/top_nav.html
@@ -40,7 +40,11 @@
               data-bs-toggle="dropdown"
               aria-expanded="false"
             >
-              <i class="fa-solid fa-bars"></i>
+              <i
+                class="fa-solid fa-bars"
+                data-bs-toggle="tooltip"
+                title="{% trans 'Menu' %}"
+              ></i>
               <span class="visually-hidden">{% trans "Menu" %}</span>
             </a>
             <ul


### PR DESCRIPTION
This change:
* Adopts  a hamburger menu, instead of an "Admin Site" link + a user menu that uses a Gravatar icon.
* Removes duplicated "My Account" links in the left navigation panel.

| Before | After |
| --- | --- |
| <img width="217" height="182" alt="image" src="https://github.com/user-attachments/assets/7788862c-b58c-4cd9-80a3-ee96c19e6e92" /> | <img width="219" height="249" alt="image" src="https://github.com/user-attachments/assets/32880590-c751-48ff-b877-6223e270ad8e" /> |
| <img width="219" height="358" alt="image" src="https://github.com/user-attachments/assets/2a5eb404-8c43-4efc-89bd-194c0fd02526" /> | <img width="219" height="210" alt="image" src="https://github.com/user-attachments/assets/974e6474-9087-46a0-a3c5-74d9a13c63c9" /> |
