### PR TITLE
Encrypt API password

### DIFF
--- a/apps/forwarding/forms.py
+++ b/apps/forwarding/forms.py
@@ -9,20 +9,33 @@ from .models import ForwardingConfig, ForwardingDestination
 class CreateForwardingDestinationForm(forms.ModelForm):
     """Form for creating ForwardingDestination objects."""
 
-    class Meta:
-        model = ForwardingDestination
-        fields = ('name', 'api_url', 'api_username', 'api_password')
-        widgets = {
-            'api_password': forms.PasswordInput(),
-        }
-
-
-class EditForwardingDestinationForm(forms.ModelForm):
-    """Form for editing ForwardingDestination objects."""
+    api_password = forms.CharField(
+        widget=forms.PasswordInput(),
+        required=False,
+        help_text=ForwardingDestination.api_password_encrypted.field.help_text,
+    )
 
     class Meta:
         model = ForwardingDestination
         fields = ('name', 'api_url', 'api_username')
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        if self.cleaned_data['api_password']:
+            instance.api_password = self.cleaned_data['api_password']
+        if commit:
+            instance.save()
+        return instance
+
+
+class EditForwardingDestinationForm(CreateForwardingDestinationForm):
+    """Form for editing ForwardingDestination objects."""
+
+    api_password = forms.CharField(
+        widget=forms.PasswordInput(),
+        required=False,
+        help_text='Leave blank to keep the existing password.',
+    )
 
 
 class ForwardingConfigForm(ScheduleFormMixin, forms.ModelForm):

--- a/apps/forwarding/migrations/0005_rename_and_resize_api_password.py
+++ b/apps/forwarding/migrations/0005_rename_and_resize_api_password.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forwarding', '0004_rename_triggering_user_forwardingrun_triggered_by_and_more'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='forwardingdestination',
+            old_name='api_password',
+            new_name='api_password_encrypted',
+        ),
+        migrations.AlterField(
+            model_name='forwardingdestination',
+            name='api_password_encrypted',
+            field=models.CharField(
+                blank=True,
+                help_text='Password for basic authentication',
+                max_length=500,
+            ),
+        ),
+    ]

--- a/apps/forwarding/migrations/0006_encrypt_existing_api_passwords.py
+++ b/apps/forwarding/migrations/0006_encrypt_existing_api_passwords.py
@@ -1,0 +1,44 @@
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.db import migrations
+
+
+def encrypt_api_passwords(apps, schema_editor):
+    """Encrypt existing plaintext API passwords."""
+    ForwardingDestination = apps.get_model('forwarding', 'ForwardingDestination')
+
+    fernet_key = settings.FERNET_KEYS[0]
+    cipher = Fernet(fernet_key.encode() if isinstance(fernet_key, str) else fernet_key)
+
+    for destination in ForwardingDestination.objects.all():
+        if destination.api_password_encrypted:
+            plaintext = destination.api_password_encrypted
+            encrypted = cipher.encrypt(plaintext.encode())
+            destination.api_password_encrypted = encrypted.decode()
+            destination.save(update_fields=['api_password_encrypted'])
+
+
+def decrypt_api_passwords(apps, schema_editor):
+    """Decrypt API passwords back to plaintext (for rollback)."""
+    ForwardingDestination = apps.get_model('forwarding', 'ForwardingDestination')
+
+    fernet_key = settings.FERNET_KEYS[0]
+    cipher = Fernet(fernet_key.encode() if isinstance(fernet_key, str) else fernet_key)
+
+    for destination in ForwardingDestination.objects.all():
+        if destination.api_password_encrypted:
+            encrypted = destination.api_password_encrypted
+            decrypted = cipher.decrypt(encrypted.encode())
+            destination.api_password_encrypted = decrypted.decode()
+            destination.save(update_fields=['api_password_encrypted'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forwarding', '0005_rename_and_resize_api_password'),
+    ]
+
+    operations = [
+        migrations.RunPython(encrypt_api_passwords, decrypt_api_passwords),
+    ]

--- a/apps/forwarding/models.py
+++ b/apps/forwarding/models.py
@@ -1,4 +1,6 @@
 import reversion
+from cryptography.fernet import Fernet, MultiFernet
+from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -21,11 +23,37 @@ class ForwardingDestination(BaseModel):
         blank=True,
         help_text=_('Username for basic authentication'),
     )
-    api_password = models.CharField(
-        max_length=200,
+    api_password_encrypted = models.CharField(
+        max_length=500,
         blank=True,
         help_text=_('Password for basic authentication'),
     )
+
+    @property
+    def api_password(self):
+        """Decrypt and return the API password."""
+        if not self.api_password_encrypted:
+            return ''
+
+        fernet_keys = (  # Include rotated keys for decryption
+            key.encode() if isinstance(key, str) else key
+            for key in settings.FERNET_KEYS
+        )
+        fernet = MultiFernet([Fernet(k) for k in fernet_keys])
+        decrypted = fernet.decrypt(self.api_password_encrypted.encode())
+        return decrypted.decode()
+
+    @api_password.setter
+    def api_password(self, value):
+        """Encrypt and store the API password."""
+        if not value:
+            self.api_password_encrypted = ''
+            return
+
+        key = settings.FERNET_KEYS[0]  # Encrypt using the current key
+        fernet = Fernet(key.encode() if isinstance(key, str) else key)
+        encrypted = fernet.encrypt(value.encode())
+        self.api_password_encrypted = encrypted.decode()
 
     def __str__(self):
         return self.name

--- a/templates/forwarding/edit_destination.html
+++ b/templates/forwarding/edit_destination.html
@@ -27,6 +27,14 @@
         <div>{{ form.api_username }}</div>
         {{ form.api_username.errors }}
       </div>
+      <div class="mb-3">
+        <label for="{{ form.api_password.id_for_label }}" class="form-label"
+          >{% trans "API Password" %}</label
+        >
+        <div>{{ form.api_password }}</div>
+        {% if form.api_password.help_text %}<div class="form-text">{{ form.api_password.help_text }}</div>{% endif %}
+        {{ form.api_password.errors }}
+      </div>
       <div class="d-flex gap-2">
         <div>
           <button class="btn btn-primary" type="submit">


### PR DESCRIPTION
This change does two things:

* It uses symmetric Fernet encryption to encrypt API passwords for data forwarding -- the same mechanism used for database passwords and CommCare API keys.
* It adds a field to the Edit Destination form so that users can change API passwords.
